### PR TITLE
Cleanup and remove redundant checking for overwriting headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
+        env:
+          update: true
         with:
           php-version: ${{ matrix.php }}
           ini-values: date.timezone='UTC'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -68,6 +68,6 @@ jobs:
       - name: Run infection
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          vendor/bin/roave-infection-static-analysis-plugin -j2 --git-diff-filter=A --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --only-covered
+          vendor/bin/roave-infection-static-analysis-plugin -j2 --git-diff-filter=AM --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --only-covered
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,6 +6,8 @@ filter:
     - "src/*"
 
 build:
+  image: default-bionic
+
   environment:
     php:
       version: 8.0.11

--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,9 @@
     "require-dev": {
         "httpsoft/http-message": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "roave/infection-static-analysis-plugin": "^1.10",
+        "roave/infection-static-analysis-plugin": "^1.13",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.12",
+        "vimeo/psalm": "^4.18",
         "yiisoft/test-support": "^1.3"
     },
     "autoload": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,5 +7,8 @@
 >
     <projectFiles>
         <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
     </projectFiles>
 </psalm>

--- a/src/SapiEmitter.php
+++ b/src/SapiEmitter.php
@@ -12,7 +12,6 @@ use Yiisoft\Yii\Runner\Http\Exception\HeadersHaveBeenSentException;
 use function flush;
 use function in_array;
 use function sprintf;
-use function strtolower;
 
 /**
  * `SapiEmitter` sends a response using standard PHP Server API i.e. with {@see header()} and "echo".
@@ -66,16 +65,13 @@ final class SapiEmitter
         if (headers_sent()) {
             throw new HeadersHaveBeenSentException();
         }
+
         header_remove();
 
         // Send headers.
         foreach ($response->getHeaders() as $header => $values) {
-            /** @var string $header */
-            $replaceFirst = strtolower($header) !== 'set-cookie';
-
             foreach ($values as $value) {
-                header("$header: $value", $replaceFirst);
-                $replaceFirst = false;
+                header("$header: $value", false);
             }
         }
 
@@ -91,6 +87,7 @@ final class SapiEmitter
             return;
         }
 
+        // Adds a `Content Length` header if a body exists, and it has not been added before.
         if (!$withoutContentLength && !$response->hasHeader('Content-Length')) {
             $contentLength = $response->getBody()->getSize();
 
@@ -122,7 +119,6 @@ final class SapiEmitter
             return false;
         }
 
-        // Check if body is empty.
         $body = $response->getBody();
 
         if (!$body->isReadable()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Removes redundant checking for overwriting headers when emitting. Because all previously installed headers are removed by the `header_remove()` function.