### PR TITLE
Fix incorrect handling response that did not close its own output buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Chg #76: Allow to use any PSR logger, `NullLogger` by default (@vjik)
 - Chg #77: Remove `ServerRequestFactory` (@vjik)
 - Chg #77: Mark `SapiEmitter` as internal (@vjik)
+- Bug #54: Fix incorrect handling response that did not close its own output buffers (@vjik)
 
 ## 2.3.0 March 10, 2024
 

--- a/src/SapiEmitter.php
+++ b/src/SapiEmitter.php
@@ -56,6 +56,7 @@ final class SapiEmitter
      */
     public function emit(ResponseInterface $response, bool $withoutBody = false): void
     {
+        $level = ob_get_level();
         $status = $response->getStatusCode();
         $withoutBody = $withoutBody || !$this->shouldOutputBody($response);
         $withoutContentLength = $withoutBody || $response->hasHeader('Transfer-Encoding');
@@ -108,18 +109,16 @@ final class SapiEmitter
          */
         flush();
 
-        $this->emitBody($response);
+        $this->emitBody($response, $level);
     }
 
-    private function emitBody(ResponseInterface $response): void
+    private function emitBody(ResponseInterface $response, int $level): void
     {
         $body = $response->getBody();
 
         if ($body->isSeekable()) {
             $body->rewind();
         }
-
-        $level = ob_get_level();
 
         $size = $body->getSize();
         if ($size !== null && $size <= $this->bufferSize) {

--- a/tests/SapiEmitterTest.php
+++ b/tests/SapiEmitterTest.php
@@ -336,14 +336,14 @@ final class SapiEmitterTest extends TestCase
 
     public function testNotClosedBuffer(): void
     {
-        $response1 = new ClosureResponse(static function(){
+        $response1 = new ClosureResponse(static function() {
             return '1';
         });
-        $response2 = new ClosureResponse(static function(){
+        $response2 = new ClosureResponse(static function() {
             ob_start();
             return '2';
         });
-        $response3 = new ClosureResponse(static function(){
+        $response3 = new ClosureResponse(static function() {
             return '3';
         });
 

--- a/tests/Support/ClosureResponse.php
+++ b/tests/Support/ClosureResponse.php
@@ -67,7 +67,7 @@ final class ClosureResponse implements ResponseInterface
 
     public function getBody(): StreamInterface
     {
-        return $this->stream ?? $this->stream = (new StreamFactory())->createStream(call_user_func($this->body));
+        return $this->stream ?? $this->stream = (new StreamFactory())->createStream(($this->body)());
     }
 
     public function withBody(StreamInterface $body): MessageInterface

--- a/tests/Support/ClosureResponse.php
+++ b/tests/Support/ClosureResponse.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Runner\Http\Tests\Support;
+
+use Closure;
+use HttpSoft\Message\StreamFactory;
+use LogicException;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+final class ClosureResponse implements ResponseInterface
+{
+    private ?StreamInterface $stream = null;
+
+    public function __construct(
+        private Closure $body,
+    ) {
+    }
+
+    public function getProtocolVersion(): string
+    {
+        return '1.1';
+    }
+
+    public function withProtocolVersion(string $version): MessageInterface
+    {
+        throw new LogicException('Not implemented.');
+    }
+
+    public function getHeaders(): array
+    {
+        return [];
+    }
+
+    public function hasHeader(string $name): bool
+    {
+        return false;
+    }
+
+    public function getHeader(string $name): array
+    {
+        throw new LogicException('Not implemented.');
+    }
+
+    public function getHeaderLine(string $name): string
+    {
+        throw new LogicException('Not implemented.');
+    }
+
+    public function withHeader(string $name, $value): MessageInterface
+    {
+        throw new LogicException('Not implemented.');
+    }
+
+    public function withAddedHeader(string $name, $value): MessageInterface
+    {
+        throw new LogicException('Not implemented.');
+    }
+
+    public function withoutHeader(string $name): MessageInterface
+    {
+        throw new LogicException('Not implemented.');
+    }
+
+    public function getBody(): StreamInterface
+    {
+        return $this->stream ?? $this->stream = (new StreamFactory())->createStream(call_user_func($this->body));
+    }
+
+    public function withBody(StreamInterface $body): MessageInterface
+    {
+        throw new LogicException('Not implemented.');
+    }
+
+    public function getStatusCode(): int
+    {
+        return 200;
+    }
+
+    public function withStatus(int $code, string $reasonPhrase = ''): ResponseInterface
+    {
+        throw new LogicException('Not implemented.');
+    }
+
+    public function getReasonPhrase(): string
+    {
+        return 'OK';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
Fix #54 
