### PR TITLE
Don't remove `Content-Length` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #91: Minor refactor internal class `RequestFactory`: explicitly mark read-only properties and add type to
   parameter of `create()` method (@vjik)
+- Bug #93: Don't remove `Content-Length` header if it is set and called emit without body (@vjik)
 
 ## 3.1.0 February 21, 2025
 

--- a/src/SapiEmitter.php
+++ b/src/SapiEmitter.php
@@ -59,7 +59,7 @@ final class SapiEmitter
         $level = ob_get_level();
         $status = $response->getStatusCode();
         $withoutBody = $withoutBody || !$this->shouldOutputBody($response);
-        $withoutContentLength = $withoutBody || $response->hasHeader('Transfer-Encoding');
+        $withoutContentLength = $response->hasHeader('Transfer-Encoding');
 
         if ($withoutContentLength) {
             $response = $response->withoutHeader('Content-Length');

--- a/tests/SapiEmitterTest.php
+++ b/tests/SapiEmitterTest.php
@@ -116,17 +116,31 @@ final class SapiEmitterTest extends TestCase
         $this->assertContains('X-Test: 42', $this->getHeaders());
     }
 
-    public function testNoBodyAndContentLengthIfEmitToldSo(): void
+    public function testNoBodyAndNoAutoAddedContentLengthIfEmitWithoutBody(): void
     {
         $response = $this->createResponse(Status::OK, ['X-Test' => 1], 'Example body');
 
-        $this
-            ->createEmitter()
-            ->emit($response, true);
+        $this->createEmitter()->emit($response, true);
 
         $this->assertSame(Status::OK, $this->getResponseCode());
         $this->assertTrue(HTTPFunctions::hasHeader('X-Test'));
         $this->assertFalse(HTTPFunctions::hasHeader('Content-Length'));
+        $this->expectOutputString('');
+    }
+
+    public function testNoBodyAndKeepContentLengthIfEmitWithoutBody(): void
+    {
+        $response = $this->createResponse(
+            Status::OK,
+            ['X-Test' => 1, 'Content-Length' => 12],
+            'Example body'
+        );
+
+        $this->createEmitter()->emit($response, true);
+
+        $this->assertSame(Status::OK, $this->getResponseCode());
+        $this->assertTrue(HTTPFunctions::hasHeader('X-Test'));
+        $this->assertTrue(HTTPFunctions::hasHeader('Content-Length'));
         $this->expectOutputString('');
     }
 
@@ -148,7 +162,7 @@ final class SapiEmitterTest extends TestCase
     public function testNoContentLengthHeaderWhenBodyIsEmpty(): void
     {
         $length = 100;
-        $response = $this->createResponse(Status::OK, ['Content-Length' => $length, 'X-Test' => 1], '');
+        $response = $this->createResponse(Status::OK, ['X-Test' => 1], '');
 
         $this
             ->createEmitter()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

