### PR TITLE
Fix emitter exception handling scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.2.2 under development
 
-- Bug: Don't route emitter failures through `ErrorCatcher` in `HttpApplicationRunner` (@samdark)
+- Bug #100: Don't route emitter failures through `ErrorCatcher` in `HttpApplicationRunner` (@samdark)
 
 ## 3.2.1 December 20, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.2.2 under development
 
-- no changes in this release.
+- Bug: Don't route emitter failures through `ErrorCatcher` in `HttpApplicationRunner` (@samdark)
 
 ## 3.2.1 December 20, 2025
 

--- a/src/HttpApplicationRunner.php
+++ b/src/HttpApplicationRunner.php
@@ -215,8 +215,8 @@ final class HttpApplicationRunner extends ApplicationRunner
 
         $request = $request->withAttribute('applicationStartTime', $startTime);
         try {
-            $application->start();
             try {
+                $application->start();
                 $response = $application->handle($request);
             } catch (Throwable $throwable) {
                 $handler = new ThrowableHandler($throwable);

--- a/src/HttpApplicationRunner.php
+++ b/src/HttpApplicationRunner.php
@@ -216,17 +216,18 @@ final class HttpApplicationRunner extends ApplicationRunner
         $request = $request->withAttribute('applicationStartTime', $startTime);
         try {
             $application->start();
-            $response = $application->handle($request);
-            $this->emit($emitter, $request, $response);
-        } catch (Throwable $throwable) {
-            $handler = new ThrowableHandler($throwable);
-            /**
-             * @var ResponseInterface
-             * @psalm-suppress MixedMethodCall
-             */
-            $response = $container
-                ->get(ErrorCatcher::class)
-                ->process($request, $handler);
+            try {
+                $response = $application->handle($request);
+            } catch (Throwable $throwable) {
+                $handler = new ThrowableHandler($throwable);
+                /**
+                 * @var ResponseInterface
+                 * @psalm-suppress MixedMethodCall
+                 */
+                $response = $container
+                    ->get(ErrorCatcher::class)
+                    ->process($request, $handler);
+            }
             $this->emit($emitter, $request, $response);
         } finally {
             $application->afterEmit($response ?? null);

--- a/tests/HttpApplicationRunnerTest.php
+++ b/tests/HttpApplicationRunnerTest.php
@@ -159,10 +159,10 @@ final class HttpApplicationRunnerTest extends TestCase
 
     public function testHeadersHaveBeenSentException(): void
     {
-        $runner = new HttpApplicationRunner(
+        $runner = (new HttpApplicationRunner(
             rootPath: __DIR__ . '/Support',
             emitter: new EmitterWithHeadersHaveBeenSentException(),
-        );
+        ))->withContainer($this->createContainer(false, true));
 
         $exception = null;
         try {
@@ -179,6 +179,16 @@ final class HttpApplicationRunnerTest extends TestCase
             SOLUTION,
             $exception->getSolution(),
         );
+    }
+
+    public function testRunRethrowsWhenErrorResponseCreationFails(): void
+    {
+        $runner = $this->runner->withContainer($this->createContainer(true, true));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Failure while creating error response');
+
+        $runner->run();
     }
 
     #[TestWith([true])]
@@ -306,10 +316,13 @@ final class HttpApplicationRunnerTest extends TestCase
         $this->expectOutputString('');
     }
 
-    private function createContainer(bool $throwException = false): ContainerInterface
+    private function createContainer(
+        bool $throwException = false,
+        bool $throwOnErrorResponseCreation = false,
+    ): ContainerInterface
     {
         $containerConfig = ContainerConfig::create()
-            ->withDefinitions($this->createDefinitions($throwException));
+            ->withDefinitions($this->createDefinitions($throwException, $throwOnErrorResponseCreation));
         return new Container($containerConfig);
     }
 
@@ -318,7 +331,7 @@ final class HttpApplicationRunnerTest extends TestCase
         return new Config(new ConfigPaths(__DIR__ . '/Support', 'config'), paramsGroup: 'params-web');
     }
 
-    private function createDefinitions(bool $throwException): array
+    private function createDefinitions(bool $throwException, bool $throwOnErrorResponseCreation): array
     {
         return [
             EventDispatcherInterface::class => SimpleEventDispatcher::class,
@@ -330,10 +343,19 @@ final class HttpApplicationRunnerTest extends TestCase
             UriFactoryInterface::class => UriFactory::class,
             UploadedFileFactoryInterface::class => UploadedFileFactory::class,
 
-            ThrowableResponseFactoryInterface::class => [
-                'class' => ThrowableResponseFactory::class,
-                'forceContentType()' => ['text/plain'],
-            ],
+            ThrowableResponseFactoryInterface::class => $throwOnErrorResponseCreation
+                ? static fn() => new class () implements ThrowableResponseFactoryInterface {
+                    public function create(
+                        Throwable $throwable,
+                        ServerRequestInterface $request
+                    ): ResponseInterface {
+                        throw new Exception('Failure while creating error response', previous: $throwable);
+                    }
+                }
+                : [
+                    'class' => ThrowableResponseFactory::class,
+                    'forceContentType()' => ['text/plain'],
+                ],
 
             Application::class => [
                 '__construct()' => [

--- a/tests/HttpApplicationRunnerTest.php
+++ b/tests/HttpApplicationRunnerTest.php
@@ -319,8 +319,7 @@ final class HttpApplicationRunnerTest extends TestCase
     private function createContainer(
         bool $throwException = false,
         bool $throwOnErrorResponseCreation = false,
-    ): ContainerInterface
-    {
+    ): ContainerInterface {
         $containerConfig = ContainerConfig::create()
             ->withDefinitions($this->createDefinitions($throwException, $throwOnErrorResponseCreation));
         return new Container($containerConfig);
@@ -348,8 +347,7 @@ final class HttpApplicationRunnerTest extends TestCase
                     public function create(
                         Throwable $throwable,
                         ServerRequestInterface $request
-                    ): ResponseInterface
-                    {
+                    ): ResponseInterface {
                         throw new Exception('Failure while creating error response', previous: $throwable);
                     }
                 }

--- a/tests/HttpApplicationRunnerTest.php
+++ b/tests/HttpApplicationRunnerTest.php
@@ -319,7 +319,8 @@ final class HttpApplicationRunnerTest extends TestCase
     private function createContainer(
         bool $throwException = false,
         bool $throwOnErrorResponseCreation = false,
-    ): ContainerInterface {
+    ): ContainerInterface
+    {
         $containerConfig = ContainerConfig::create()
             ->withDefinitions($this->createDefinitions($throwException, $throwOnErrorResponseCreation));
         return new Container($containerConfig);
@@ -347,7 +348,8 @@ final class HttpApplicationRunnerTest extends TestCase
                     public function create(
                         Throwable $throwable,
                         ServerRequestInterface $request
-                    ): ResponseInterface {
+                    ): ResponseInterface
+                    {
                         throw new Exception('Failure while creating error response', previous: $throwable);
                     }
                 }

--- a/tests/HttpApplicationRunnerTest.php
+++ b/tests/HttpApplicationRunnerTest.php
@@ -159,10 +159,10 @@ final class HttpApplicationRunnerTest extends TestCase
 
     public function testHeadersHaveBeenSentException(): void
     {
-        $runner = (new HttpApplicationRunner(
+        $runner = new HttpApplicationRunner(
             rootPath: __DIR__ . '/Support',
             emitter: new EmitterWithHeadersHaveBeenSentException(),
-        ))->withContainer($this->createContainer(false, true));
+        );
 
         $exception = null;
         try {

--- a/tests/HttpApplicationRunnerTest.php
+++ b/tests/HttpApplicationRunnerTest.php
@@ -319,8 +319,7 @@ final class HttpApplicationRunnerTest extends TestCase
     private function createContainer(
         bool $throwException = false,
         bool $throwOnErrorResponseCreation = false,
-    ): ContainerInterface
-    {
+    ): ContainerInterface {
         $containerConfig = ContainerConfig::create()
             ->withDefinitions($this->createDefinitions($throwException, $throwOnErrorResponseCreation));
         return new Container($containerConfig);


### PR DESCRIPTION
https://github.com/yiisoft/yii-runner-frankenphp/commit/3cee30048a2abcc5687c72f1ff4cf409627cb72d

Keeps emitter failures out of the application error handling path. Added a regression test for rethrowing when error response creation fails.